### PR TITLE
Fix bulk create action for creating 1 barcode

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: http://github.com/sanger/lims-api.git
-  revision: 9839b17f777d89742bd16c7ac41b4e0efd6a2092
+  revision: 966a0f6bf2aa0b4f7eda54f3a98c115bab5a7b54
   branch: master
   specs:
-    lims-api (2.1.1)
+    lims-api (2.2.0)
       active_support
       bunny (= 0.9.0.pre10)
       json
@@ -28,10 +28,10 @@ GIT
 
 GIT
   remote: http://github.com/sanger/lims-laboratory-app.git
-  revision: 2c9085be7e685fccaae32bb49410a27e370e265c
+  revision: 965f93a0e7027342b7f98efe54777dbe697928f8
   branch: master
   specs:
-    lims-laboratory-app (1.0.3)
+    lims-laboratory-app (1.3.0)
 
 GIT
   remote: http://github.com/sanger/psd_logger.git
@@ -122,7 +122,7 @@ GEM
     rspec-expectations (2.8.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.8.0)
-    sequel (3.47.0)
+    sequel (3.48.0)
     shotgun (0.9)
       rack (>= 1.0)
     slop (3.4.5)

--- a/lib/lims-support-app/barcode/create_action_shared.rb
+++ b/lib/lims-support-app/barcode/create_action_shared.rb
@@ -4,24 +4,22 @@ module Lims::SupportApp
   class Barcode
     module CreateActionShared
 
-      def create_barcode(labware, role, contents, session, number_of_barcode=1)
+      def create_barcode(labware, role, contents, session, number_of_barcode=nil)
         barcodes = []
-        number_of_barcode.times do
-          barcode = Lims::SupportApp::Barcode.new(
+        (number_of_barcode || 1).times do
+          barcode = Lims::SupportApp::Barcode.new({
             :labware  => labware,
             :role     => role,
-            :contents => contents)
+            :contents => contents
+          })
 
           barcode.sanger_code(Barcode::new_barcode)
-
           barcode.ean13_code = barcode.calculate_ean13
-
           session << barcode
-          
-          barcodes << { :barcode => barcode, :uuid => session.uuid_for!(barcode) }
+          barcodes << {:barcode => barcode, :uuid => session.uuid_for!(barcode)}
         end
 
-        number_of_barcode == 1 ? barcodes[0] : { :barcodes => barcodes.map { |b| b[:barcode] } }
+        number_of_barcode ? {:barcodes => barcodes.map { |b| b[:barcode] }} : barcodes.first
       end
     end
   end


### PR DESCRIPTION
Even when we create only 1 barcode using the bulk create barcode action, the barcode is returned in an array of barcodes.
